### PR TITLE
Fixed: Proxy deleteHandle method have to return true

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -174,6 +174,7 @@ var DDPServer = function(opts) {
         deleteProperty: function(_, field) {
           delete doc[field];
           sendChanged(id, {}, [field]);
+          return true;
         }
       });
       for (var client in subscriptions)

--- a/lib.js
+++ b/lib.js
@@ -221,6 +221,7 @@ var DDPServer = function(opts) {
       },
       deleteProperty: function(_, id) {
         remove(id);
+        return true;
       }
     });
   }


### PR DESCRIPTION
Run code:

``` js
var server = new DDPServer();
var todoList = server.publish("todolist");
todoList[0] = { title: "Cook dinner", done: false };
todoList[1] = { title: "Water the plants", done: true };
todoList[0].done = true;

// error here
delete todoList[1]
```

And receive next error:

```
TypeError: 'deleteProperty' on proxy: trap returned falsish for property '1'
    at Timeout._onTimeout (/home/.../dist/test/ddp.js:57:12)
    at tryOnTimeout (timers.js:224:11)
    at Timer.listOnTimeout (timers.js:198:5)
```

> The deleteProperty method must return a Boolean indicating whether or not the property has been successfully deleted. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/deleteProperty)
